### PR TITLE
fix debian packaging

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,12 +1,11 @@
 #! /usr/bin/make -f
 
-build:
-	dh_testdir
-	$(MAKE) ffmpeg libass
-	scripts/mpv-config --prefix=/usr
-	$(MAKE) -C mpv
-
 %:
 	exec dh $@ --parallel
 
 override_dh_auto_build:
+	$(MAKE) ffmpeg 
+	$(MAKE) libass
+	scripts/mpv-config --prefix=/usr
+	$(MAKE) -C mpv
+


### PR DESCRIPTION
the rules file contained some redundancies that made the Launchpad build system fail to build mpv; this cleans it up so that it's interpreted correctly.
