### PR TITLE
Remove non-portable sort usage from update script

### DIFF
--- a/update
+++ b/update
@@ -40,7 +40,11 @@ do_releasetag()
 {
     (
         cd "$1"
-        version=`git tag | grep "^$2[0-9]" | sort -V | tail -n 1`
+        if [ "$1" == "ffmpeg" ]; then
+            version=`git tag | grep "^n[0-9]" | sort -t. | tail -n 1`
+        else
+            version=`git tag | grep "^$2[0-9]" | sort -t. -n -k1,1 -k2,2 -k3,3 | tail -n 1`
+        fi
         git checkout --detach refs/tags/"$version"
     )
 }


### PR DESCRIPTION
It failed with the following error on OSX:

```
+ do_releasetag ffmpeg n
+ cd ffmpeg
++ git tag
++ grep '^n[0-9]'
++ sort -V
++ tail -n 1
sort: invalid option -- V
Try `sort --help' for more information.
+ version=
+ git checkout --detach refs/tags/
fatal: git checkout: --detach does not take a path argument 'refs/tags/'
```

I couldn't find any better sort solution but the special case for ffmpeg. :(
