### PR TITLE
Fix bashism in debian/rules, handle errors better

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -11,7 +11,7 @@ endif
 # ammounts to the same thing.
 ifneq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
 	NUMJOBS = $(patsubst parallel=%,%,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
-	# use MFLAGS, rather than MAKEFLAGS as the latter is mysteriously given the "w" flag without "-"
+	# use MFLAGS, rather than MAKEFLAGS as the latter is used by make internally
 	MFLAGS += -j$(NUMJOBS) 
 	WAFFLAGS += -j$(NUMJOBS)
 endif
@@ -37,15 +37,18 @@ install:
 # the dependencies must be built before mpv is configured
 ffmpeg_config:
 	scripts/ffmpeg-config --enable-libx264 --enable-libmp3lame
-ffmpeg_build:ffmpeg_config
+
+ffmpeg_build: ffmpeg_config
 	scripts/ffmpeg-build $(MFLAGS)
+
 libass_config:
 	scripts/libass-config
-libass_build:libass_config
+
+libass_build: libass_config
 	scripts/libass-build $(MFLAGS)
 
 # put the config in the right place and drop the local/ since it's package managed now
-override_dh_auto_configure:ffmpeg_build libass_build
+override_dh_auto_configure: ffmpeg_build libass_build
 	scripts/mpv-config --prefix=/usr --confdir=/etc/mpv 
 
 override_dh_auto_build:
@@ -53,10 +56,10 @@ override_dh_auto_build:
 
 # call waf to install to the debian packageing dir
 override_dh_auto_install:
-	(cd mpv;python ./waf -v install --destdir=../debian/mpv)
+	cd mpv && python waf -v install --destdir=../debian/mpv
 
-#call all the cleans
+# call all the cleans
 override_dh_auto_clean:
 	scripts/mpv-clean
 	scripts/ffmpeg-clean
-	scripts/libass-clean 
+	scripts/libass-clean


### PR DESCRIPTION
POSIX sh requires a ';' before a closing ')'.
However, in this case the () were not even necessary,
so leave them out entirely (make already starts a separate
shell process for each command).

Also tidy up the whitespace a little to make things easier
on the eye.
