### PR TITLE
Escape arguments to sed in scripts/debian-update-versions

### DIFF
--- a/scripts/debian-update-versions
+++ b/scripts/debian-update-versions
@@ -20,8 +20,13 @@ get_timestamp_commit()
 }
 
 do_subst() {
-    sed  -e "0,/^mpv (.*)/s/(.*)/($1)/" \
-	-e "s/^  \* local build.*/  \* local build with ffmpeg $2, libass $3/" \
+    #escape the arguments, so they don't mess with sed
+    ESCARG1=$(echo "$1"|sed -e 's/[\/&]/\\&/g')
+    ESCARG2=$(echo "$2"|sed -e 's/[\/&]/\\&/g')
+    ESCARG3=$(echo "$3"|sed -e 's/[\/&]/\\&/g')
+
+    sed  -e "0,/^mpv (.*)/s/(.*)/($ESCARG1)/" \
+	-e "s/^  \* local build.*/  \* local build with ffmpeg $ESCARG2, libass $ESCARG3/" \
 	-e"s/\(^ -- Local User <localuser@localhost>\).*/\1  $(date -R)/" debian/changelog.TEMPLATE > debian/changelog
 }
 


### PR DESCRIPTION
Before, when running `rebuild`, it would abort with the following error:

```
sed: -e expression #1, char 23: unknown option to `s'
```

in the script `scripts/debian-update-versions`. This happened because the sed expressions in the function `do_subst()` contained arguments that had slashes in them, which is a special character for sed. Escaping special sed characters solves this.
