### PR TITLE
debian: fix Build-Depends on libgnutls-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Build-Depends:
  libfreetype6-dev,
  libfribidi-dev,
  libgl1-mesa-dev,
- libgnutls-dev,
+ libgnutls-dev | libgnutls28-dev,
  libgsm1-dev,
  libguess-dev,
 # libharfbuzz-dev,


### PR DESCRIPTION
In Debian Jessie libgnutls-dev package is currently non-installable due to [migration](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=767610) to gnutls28. Allow building mpv Debian package with either libgnutls-dev or libgnutls28-dev package installed.
