### PR TITLE
debian: Remove dependency on  libschroedinger-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -43,7 +43,6 @@ Build-Depends:
  libpulse-dev,
  librtmp-dev,
  librubberband-dev,
- libschroedinger-dev,
  libsmbclient-dev,
  libssh-dev,
  libsoxr-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -46,7 +46,6 @@ ffmpeg_config: libass_build
 		--enable-netcdf \
 		--enable-libopus \
 		--enable-libpulse \
-		--enable-libschroedinger \
 		--enable-libsoxr \
 		--enable-libspeex \
 		--enable-libssh \


### PR DESCRIPTION
libschroedinger-dev is being removed from development in debian and is
also absent from the Ubuntu 17.04 development branch.

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=845037 for more details.
