### PR TITLE
add support for requesting mbedtls on ffmpeg options

### DIFF
--- a/scripts/ffmpeg-config
+++ b/scripts/ffmpeg-config
@@ -17,7 +17,8 @@ OPTIONS="$OPTIONS $USER_OPTS"
 
 # Do FFmpeg's job.
 if ! ( echo "$OPTIONS" | grep -q -e --enable-openssl ) &&
-   ! ( echo "$OPTIONS" | grep -q -e --enable-gnutls ) ;
+   ! ( echo "$OPTIONS" | grep -q -e --enable-gnutls ) &&
+   ! ( echo "$OPTIONS" | grep -q -e --enable-mbedtls ) ;
 then
     if pkg-config gnutls ; then
         OPTIONS="$OPTIONS --enable-gnutls"


### PR DESCRIPTION
mbedtls currently does not ship with a package config file so it's not possible to use the `pkg-config` trick for automatic detection. This just teaches the existing build script for ffmpeg to honor the `--enable-mbedtls` option and avoid using another SSL/TLS library.