### PR TITLE
Remove --enable-dvdread from the Debian build rules.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,6 @@ Build-Depends:
  libcaca-dev,
  libcdio-paranoia-dev,
  libdvdnav-dev,
- libdvdread-dev,
  libegl1-mesa-dev,
  libfontconfig-dev,
  libfreetype6-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -63,7 +63,6 @@ ffmpeg_build: ffmpeg_config
 override_dh_auto_configure: ffmpeg_build libass_build
 	scripts/mpv-config --prefix=/usr --confdir=/etc/mpv \
 		--enable-openal \
-		--enable-dvdread \
 		--enable-dvdnav \
 		--enable-cdda \
 		--enable-libsmbclient \


### PR DESCRIPTION
Fixes #120.