### PR TITLE
README.rst: remove reference to homebrew-mpv repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,10 +5,6 @@ This is a collection of scripts to make downloading and building mpv, ffmpeg
 and libass easier. ffmpeg and libass get special treatment, because they are
 essential, and distribution packages are often too old or too broken.
 
-If you are running Mac OSX and using homebrew we provide homebrew-mpv_, an up
-to date formula that compiles mpv with sensible dependencies and defaults for
-OSX.
-
 Generic Instructions
 ====================
 
@@ -192,4 +188,3 @@ Report bugs to the `issues tracker`_ provided by GitHub to send us bug
 reports or feature requests.
 
 .. _issues tracker: https://github.com/mpv-player/mpv/issues
-.. _homebrew-mpv: https://github.com/mpv-player/homebrew-mpv


### PR DESCRIPTION
The README still referenced [`mpv-player/homebrew-mpv`](https://github.com/mpv-player/homebrew-mpv), which has been archived years ago.

However, you may want to consider reviving that repo, seeing as [the homebrew formula was removed](https://github.com/Homebrew/homebrew-core/commit/41444d526c40b93069b7f0c5414539deb0534179). There is [a cask](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/mpv.rb) but it uses [the prebuilt binaries from `stolendata`](https://laboratory.stolendata.net/~djinn/mpv_osx/) as [referenced on your website](https://mpv.io/installation/).

The formula was almost four times more popular than the cask (6,938 vs 1,848 downloads in the last 90 days), which is why I mentioned reviving the formula on your side.

I’m a Homebrew Cask maintainer, so feel free to ask any clarification on the formula vs cask.