### PR TITLE
Remove --enable-zsh-comp

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -65,8 +65,7 @@ override_dh_auto_configure: ffmpeg_build libass_build
 		--enable-openal \
 		--enable-dvdnav \
 		--enable-cdda \
-		--enable-libsmbclient \
-		--enable-zsh-comp
+		--enable-libsmbclient
 
 override_dh_auto_build:
 	scripts/mpv-build $(WAFLAGS)


### PR DESCRIPTION
This option no longer exists, as zsh completion is installed
unconditionally now.
See https://github.com/mpv-player/mpv/pull/5139