### PR TITLE
Call waf with python3 everywhere

### DIFF
--- a/scripts/mpv-clean
+++ b/scripts/mpv-clean
@@ -2,7 +2,7 @@
 test -e mpv || exit 0
 
 cd mpv
-./waf distclean
+python3 ./waf distclean
 # waf might pick up some old-configure/makefile produced files
 # also, waf clean won't remove the old binary
 rm -f DOCS/man/*/mpv.1 version.h input/input_conf.h video/out/vdpau_template.c demux/ebml_types.h demux/ebml_defs.c video/out/gl_video_shaders.h video/out/x11_icon.inc sub/osd_font.h player/lua/defaults.inc player/lua/assdraw.inc player/lua/osc.inc mpv

--- a/scripts/mpv-config
+++ b/scripts/mpv-config
@@ -21,4 +21,4 @@ esac
 echo Using mpv options: $OPTIONS
 
 cd "$BUILD"/mpv
-./waf configure $OPTIONS
+python3 ./waf configure $OPTIONS

--- a/scripts/mpv-install
+++ b/scripts/mpv-install
@@ -2,4 +2,4 @@
 set -e
 
 cd mpv
-./waf install
+python3 ./waf install

--- a/scripts/mpv-uninstall
+++ b/scripts/mpv-uninstall
@@ -2,4 +2,4 @@
 set -e
 
 cd mpv
-./waf uninstall
+python3 ./waf uninstall


### PR DESCRIPTION
This patch ensures Waf is called with Python 3 in all scripts and fixes issue #148 

Commit abc1380522f81223d09c19f2ad378948f80a9e2b on older Ubuntu versions results in "waf configure" being run with Python 2 and "waf build" being run with Python 3.