### PR TITLE
manually add libass requires in mpv-config

### DIFF
--- a/scripts/mpv-config
+++ b/scripts/mpv-config
@@ -18,6 +18,10 @@ case "$PKG_CONFIG_PATH" in
     ;;
 esac
 
+# add missing private dependencies from libass.pc
+# this is necessary due to the hybrid static / dynamic nature of the build
+export LDFLAGS="$LDFLAGS $(pkg-config --libs fontconfig harfbuzz fribidi)"
+
 echo Using mpv options: $OPTIONS
 
 cd "$BUILD"/mpv


### PR DESCRIPTION
This became necessary with
libass/libass@c9c4fed39339ffde45123013a117e06d0bb9c488

The final link of the mpv binary now works again.