### PR TITLE
use more correct manual pkg-config command for libass

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,7 @@ Build-Depends:
  automake,
  c-compiler | gcc,
  debhelper (>= 7),
+ glslang-dev,
  ladspa-sdk,
  libasound2-dev [linux-any],
  libarchive-dev,
@@ -19,6 +20,7 @@ Build-Depends:
  libdav1d-dev,
  libdvdnav-dev,
  libegl1-mesa-dev,
+ libepoxy-dev,
  libfontconfig-dev,
  libfreetype6-dev,
  libfribidi-dev,
@@ -53,7 +55,9 @@ Build-Depends:
  libvdpau-dev,
  libvorbis-dev,
  libvo-amrwbenc-dev,
+ libunwind-dev,
  libvpx-dev,
+ libvulkan-dev,
  libwayland-dev,
  libx264-dev,
  libx11-dev,
@@ -65,6 +69,8 @@ Build-Depends:
  libxss-dev,
  libxv-dev,
  libxvidcore-dev,
+ meson,
+ ninja-build,
  pkg-config,
  python3,
  python3-docutils,
@@ -84,5 +90,5 @@ Description: mplayer/mplayer2 based video player
  MPV is a versatile CLI movie player, based on mplayer and mplayer2.
  .
  This package is not part of Debian. It was created by mpv-build scripts with
- statically linked ffmpeg and libass from upstream.
+ statically linked ffmpeg, libass and libplacebo from upstream.
 Homepage:https://github.com/mpv-player/mpv-build

--- a/debian/control
+++ b/debian/control
@@ -70,12 +70,12 @@ Build-Depends:
  libxv-dev,
  libxvidcore-dev,
  meson,
+ nasm,
  ninja-build,
  pkg-config,
  python3,
  python3-docutils,
  x11proto-core-dev,
- yasm,
  zlib1g-dev
 
 Package: mpv

--- a/debian/rules
+++ b/debian/rules
@@ -11,6 +11,7 @@ ifneq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
 # use MFLAGS, rather than MAKEFLAGS as the latter is used by make internally
 	MFLAGS += -j$(NUMJOBS)
 	WAFFLAGS += -j$(NUMJOBS)
+	NINJAFLAGS += -j$(NUMJOBS)
 endif
 
 # make .PHONY all the targets that have name collisions with the scripts
@@ -36,7 +37,7 @@ libass_build: libass_config
 	scripts/libass-build $(MFLAGS)
 
 # depend on libass_build in case the user specified --enable-libass in ffmpeg_options
-ffmpeg_config: libass_build
+ffmpeg_config: libass_build libplacebo_build
 	scripts/ffmpeg-config \
 		--enable-gnutls \
 		--enable-libdav1d \
@@ -59,8 +60,14 @@ ffmpeg_config: libass_build
 ffmpeg_build: ffmpeg_config
 	scripts/ffmpeg-build $(MFLAGS)
 
+libplacebo_config:
+	scripts/libplacebo-config
+
+libplacebo_build: libplacebo_config
+	scripts/libplacebo-build $(NINJAFLAGS)
+
 # put the config in the right place and drop the local/ since it's package managed now
-override_dh_auto_configure: ffmpeg_build libass_build
+override_dh_auto_configure: ffmpeg_build libass_build libplacebo_build
 	scripts/mpv-config --prefix=/usr --confdir=/etc/mpv \
 		--enable-openal \
 		--enable-dvdnav \

--- a/scripts/debian-update-versions
+++ b/scripts/debian-update-versions
@@ -16,8 +16,8 @@ get_version()
 
 do_subst() {
     sed  -e "0,/^mpv (.*)/s/(.*)/($1)/" \
-         -e "s/^  \* local build.*/  \* local build with ffmpeg $2, libass $3/" \
+         -e "s/^  \* local build.*/  \* local build with ffmpeg $2, libass $3, libplacebo $4/" \
          -e"s/\(^ -- Local User <localuser@localhost>\).*/\1  $(date -R)/" debian/changelog.TEMPLATE > debian/changelog
 }
 
-do_subst $(get_version mpv) $(get_version ffmpeg) $(get_version libass)
+do_subst $(get_version mpv) $(get_version ffmpeg) $(get_version libass) $(get_version libplacebo)


### PR DESCRIPTION
    Actually ask for what static libass needs instead of guessing. Maybe
    extra things get included since this assumes recursive dependencies are
    also static, but I can't see how this would be a problem in practice. It
    just explicitly includes some shared object dependencies that were
    previously implicit. The resulting binary is the same size and has the
    same shared object dependencies (although in slightly different order)
    according to ldd.
