### PR TITLE
debian: disable LTO

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #! /usr/bin/make -f
 
-export DEB_BUILD_MAINT_OPTIONS:=hardening=+all
+export DEB_BUILD_MAINT_OPTIONS := hardening=+all optimize=-lto
 
 # To enable parallel building:
 # You can either set DEB_BUILD_OPTIONS=paralell=<num-procs> in your build environment


### PR DESCRIPTION
Newer versions of Ubuntu (and future versions of Debian) enable LTO by
default for package builds. This is apparently incompatible with how we
compile mpv using static builds of ffmpeg and libass.

Fixes https://github.com/mpv-player/mpv-build/issues/158

Further reading:
 - https://wiki.ubuntu.com/ToolChain/LTO
 - https://wiki.debian.org/ToolChain/LTO