### PR TITLE
build/configure: allow options with spaces

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,15 +72,39 @@ if the dependencies are not available.)
 You can put additional ffmpeg configure flags into ffmpeg_options. For
 example, to enable some dependencies needed for encoding::
 
-    echo --enable-libx264    >> ffmpeg_options
+    printf "%s\n" --enable-libx264    >> ffmpeg_options
 
-    echo --enable-libmp3lame >> ffmpeg_options
+    printf "%s\n" --enable-libmp3lame >> ffmpeg_options
 
-    echo --enable-libfdk-aac >> ffmpeg_options
+    printf "%s\n" --enable-libfdk-aac >> ffmpeg_options
 
 Do this in the mpv-build top-level directory (the same that contains
 the build scripts and this readme file). It must be done prior running
 ./build or ./rebuild.
+
+NAME_options files (where NAME is ffmpeg/mpv/libass/fribidi)
+============================================================
+
+These files can hold custom configure options which are passed to the
+respective configure scripts.
+
+Empty lines are ignored, and every non-empty line becomes a single verbatim
+argument (including leading and/or trailing spaces) when invoking the
+respective configure script.
+
+This means that shell quotes should *not* be placed at these files, and the
+values should not be indented.
+
+The files can hold arbitrary values, except empty values and values which
+contain newline[s].
+
+Except empty/with-newlines, any list of configure arguments, for instance::
+
+    ./configure   --thing=foo --libs="-L/bar -lbaz" -x abc +z
+
+can also be added to the file, like so::
+
+    printf "%s\n" --thing=foo --libs="-L/bar -lbaz" -x abc +z >> ffmpeg_options
 
 Instructions for Debian / Ubuntu package
 ========================================
@@ -172,7 +196,7 @@ Building libmpv
 
 You can enable building libmpv by enabling the configure option::
 
-    echo --enable-libmpv-shared > mpv_options
+    printf "%s\n" --enable-libmpv-shared > mpv_options
 
 Note that this will make the mpv-build scripts also enable PIC for all used
 libraries. For this reason, be sure to run ``./clean`` before rebuilding.

--- a/build
+++ b/build
@@ -3,10 +3,10 @@ set -e
 export LC_ALL=C
 
 #scripts/fribidi-config
-#scripts/fribidi-build $@
+#scripts/fribidi-build "$@"
 scripts/libass-config
-scripts/libass-build $@
+scripts/libass-build "$@"
 scripts/ffmpeg-config
-scripts/ffmpeg-build $@
+scripts/ffmpeg-build "$@"
 scripts/mpv-config
-scripts/mpv-build $@
+scripts/mpv-build "$@"

--- a/rebuild
+++ b/rebuild
@@ -4,4 +4,4 @@ export LC_ALL=C
 
 ./update
 ./clean
-./build $@
+./build "$@"

--- a/scripts/ffmpeg-build
+++ b/scripts/ffmpeg-build
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 
-make -C ffmpeg_build install $@
+make -C ffmpeg_build install "$@"

--- a/scripts/ffmpeg-config
+++ b/scripts/ffmpeg-config
@@ -3,17 +3,14 @@ set -e
 
 BUILD="$(pwd)"
 
-USER_OPTS="$@"
 if test -f "$BUILD"/ffmpeg_options ; then
-    USER_OPTS="$(cat "$BUILD"/ffmpeg_options) $USER_OPTS"
+    set -- $(cat "$BUILD"/ffmpeg_options) "$@"
 fi
-OPTIONS="--enable-gpl --disable-debug --disable-doc"
 
+OPTIONS="--enable-gpl --disable-debug --disable-doc"
 if "$BUILD"/scripts/test-libmpv ; then
     OPTIONS="$OPTIONS --enable-pic"
 fi
-
-OPTIONS="$OPTIONS $USER_OPTS"
 
 # Do FFmpeg's job.
 if ! ( echo "$OPTIONS" | grep -q -e --enable-openssl ) &&
@@ -38,8 +35,8 @@ case "$PKG_CONFIG_PATH" in
     ;;
 esac
 
-echo Using ffmpeg options: $OPTIONS
+echo Using ffmpeg options: $OPTIONS "$@"
 
 mkdir -p "$BUILD"/ffmpeg_build
 cd "$BUILD"/ffmpeg_build
-"$BUILD"/ffmpeg/configure --prefix="$BUILD"/build_libs --enable-static --disable-shared $OPTIONS
+"$BUILD"/ffmpeg/configure --prefix="$BUILD"/build_libs --enable-static --disable-shared $OPTIONS "$@"

--- a/scripts/ffmpeg-config
+++ b/scripts/ffmpeg-config
@@ -11,7 +11,7 @@ if test -f "$BUILD"/ffmpeg_options ; then
     unset -v IFS
 fi
 
-OPTIONS="--enable-gpl --disable-debug --disable-doc"
+OPTIONS="--enable-gpl --disable-debug --disable-doc --enable-static --disable-shared"
 if "$BUILD"/scripts/test-libmpv ; then
     OPTIONS="$OPTIONS --enable-pic"
 fi
@@ -43,4 +43,4 @@ echo Using ffmpeg options: $OPTIONS "$@"
 
 mkdir -p "$BUILD"/ffmpeg_build
 cd "$BUILD"/ffmpeg_build
-"$BUILD"/ffmpeg/configure --prefix="$BUILD"/build_libs --enable-static --disable-shared $OPTIONS "$@"
+"$BUILD"/ffmpeg/configure --prefix="$BUILD"/build_libs $OPTIONS "$@"

--- a/scripts/ffmpeg-config
+++ b/scripts/ffmpeg-config
@@ -2,9 +2,13 @@
 set -e
 
 BUILD="$(pwd)"
+newline="
+"
 
 if test -f "$BUILD"/ffmpeg_options ; then
+    IFS=$newline
     set -- $(cat "$BUILD"/ffmpeg_options) "$@"
+    unset -v IFS
 fi
 
 OPTIONS="--enable-gpl --disable-debug --disable-doc"

--- a/scripts/fribidi-build
+++ b/scripts/fribidi-build
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 
-make -C fribidi install -j1 # race conditions in the make rules
+make -C fribidi install "$@" -j1 # race conditions in the make rules

--- a/scripts/fribidi-config
+++ b/scripts/fribidi-config
@@ -1,6 +1,14 @@
 #!/bin/sh
 set -e
 BUILD="$(pwd)"
+newline="
+"
+
+if test -f "$BUILD"/fribidi_options ; then
+    IFS=$newline
+    set -- $(cat "$BUILD"/fribidi_options) "$@"
+    unset -v IFS
+fi
 
 OPTIONS=
 if "$BUILD"/scripts/test-libmpv ; then

--- a/scripts/fribidi-config
+++ b/scripts/fribidi-config
@@ -10,11 +10,11 @@ if test -f "$BUILD"/fribidi_options ; then
     unset -v IFS
 fi
 
-OPTIONS=
+OPTIONS="--enable-static --disable-shared --without-glib"
 if "$BUILD"/scripts/test-libmpv ; then
     OPTIONS="$OPTIONS --with-pic"
 fi
 
 cd "$BUILD"/fribidi
 ./bootstrap
-./configure --prefix="$BUILD/build_libs" --libdir="$BUILD/build_libs/lib" --enable-static --disable-shared --without-glib $OPTIONS "$@"
+./configure --prefix="$BUILD/build_libs" --libdir="$BUILD/build_libs/lib" $OPTIONS "$@"

--- a/scripts/fribidi-config
+++ b/scripts/fribidi-config
@@ -2,12 +2,11 @@
 set -e
 BUILD="$(pwd)"
 
-OPTIONS=""
-
+OPTIONS=
 if "$BUILD"/scripts/test-libmpv ; then
     OPTIONS="$OPTIONS --with-pic"
 fi
 
 cd "$BUILD"/fribidi
 ./bootstrap
-./configure --prefix="$BUILD/build_libs" --libdir="$BUILD/build_libs/lib" --enable-static --disable-shared --without-glib $OPTIONS
+./configure --prefix="$BUILD/build_libs" --libdir="$BUILD/build_libs/lib" --enable-static --disable-shared --without-glib $OPTIONS "$@"

--- a/scripts/libass-build
+++ b/scripts/libass-build
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 
-make -C libass install $@
+make -C libass install "$@"

--- a/scripts/libass-config
+++ b/scripts/libass-config
@@ -10,7 +10,7 @@ if test -f "$BUILD"/libass_options ; then
     unset -v IFS
 fi
 
-OPTIONS=
+OPTIONS="--enable-static --disable-shared"
 if "$BUILD"/scripts/test-libmpv ; then
     OPTIONS="$OPTIONS --with-pic"
 fi
@@ -26,6 +26,6 @@ esac
 
 cd "$BUILD"/libass
 # Later libass doesn't automatically run configure with autogen.sh anymore
-./autogen.sh --prefix="$BUILD/build_libs" --libdir="$BUILD/build_libs/lib" --enable-static --disable-shared $OPTIONS "$@"
-./configure  --prefix="$BUILD/build_libs" --libdir="$BUILD/build_libs/lib" --enable-static --disable-shared $OPTIONS "$@"
+./autogen.sh --prefix="$BUILD/build_libs" --libdir="$BUILD/build_libs/lib" $OPTIONS "$@"
+./configure  --prefix="$BUILD/build_libs" --libdir="$BUILD/build_libs/lib" $OPTIONS "$@"
 

--- a/scripts/libass-config
+++ b/scripts/libass-config
@@ -2,8 +2,7 @@
 set -e
 BUILD="$(pwd)"
 
-OPTIONS="$@"
-
+OPTIONS=
 if "$BUILD"/scripts/test-libmpv ; then
     OPTIONS="$OPTIONS --with-pic"
 fi
@@ -19,6 +18,6 @@ esac
 
 cd "$BUILD"/libass
 # Later libass doesn't automatically run configure with autogen.sh anymore
-./autogen.sh --prefix="$BUILD/build_libs" --libdir="$BUILD/build_libs/lib" --enable-static --disable-shared $OPTIONS
-./configure  --prefix="$BUILD/build_libs" --libdir="$BUILD/build_libs/lib" --enable-static --disable-shared $OPTIONS
+./autogen.sh --prefix="$BUILD/build_libs" --libdir="$BUILD/build_libs/lib" --enable-static --disable-shared $OPTIONS "$@"
+./configure  --prefix="$BUILD/build_libs" --libdir="$BUILD/build_libs/lib" --enable-static --disable-shared $OPTIONS "$@"
 

--- a/scripts/libass-config
+++ b/scripts/libass-config
@@ -1,6 +1,14 @@
 #!/bin/sh
 set -e
 BUILD="$(pwd)"
+newline="
+"
+
+if test -f "$BUILD"/libass_options ; then
+    IFS=$newline
+    set -- $(cat "$BUILD"/libass_options) "$@"
+    unset -v IFS
+fi
 
 OPTIONS=
 if "$BUILD"/scripts/test-libmpv ; then

--- a/scripts/mpv-build
+++ b/scripts/mpv-build
@@ -2,4 +2,4 @@
 set -e
 
 cd mpv
-python3 ./waf build $@
+python3 ./waf build "$@"

--- a/scripts/mpv-config
+++ b/scripts/mpv-config
@@ -2,9 +2,13 @@
 set -e
 
 BUILD="$(pwd)"
+newline="
+"
 
 if test -f "$BUILD"/mpv_options ; then
+    IFS=$newline
     set -- $(cat "$BUILD"/mpv_options) "$@"
+    unset -v IFS
 fi
 
 case "$PKG_CONFIG_PATH" in

--- a/scripts/mpv-config
+++ b/scripts/mpv-config
@@ -3,11 +3,9 @@ set -e
 
 BUILD="$(pwd)"
 
-USER_OPTS="$@"
 if test -f "$BUILD"/mpv_options ; then
-    USER_OPTS="$(cat "$BUILD"/mpv_options) $USER_OPTS"
+    set -- $(cat "$BUILD"/mpv_options) "$@"
 fi
-OPTIONS="$USER_OPTS"
 
 case "$PKG_CONFIG_PATH" in
   '')
@@ -22,7 +20,7 @@ esac
 # this is necessary due to the hybrid static / dynamic nature of the build
 export LDFLAGS="$LDFLAGS $(pkg-config --libs fontconfig harfbuzz fribidi)"
 
-echo Using mpv options: $OPTIONS
+echo Using mpv options: "$@"
 
 cd "$BUILD"/mpv
-python3 ./waf configure $OPTIONS
+python3 ./waf configure "$@"


### PR DESCRIPTION
This PR allows using arguments with spaces:
- Build CLI options with spaces (mainly `./build` and `./rebuild`).
- Configure CLI options with spaces (when using `scripts/NAME-config` directy).
- Configure NAME_options files values with spaces.

Where previously none of those were possible.

This addresses #172 and #175

The CLI options fixes are fairly trivial, mainly using quoted `"$@"` instead of unquoted `$@` (build scripts), and at the config scripts - using the positional parameters directly, instead of storing them in a variable for later use (which was expanded unquoted, resulting in loss of spaces).

The main change is the 3rd commit - how the NAME_options files are handled, where previously they were split to individual values based on default IFS (space, tab, newline), thus not allowing arguments with whitespaces, and this PR makes it split using newlines only.

The README was and still is instructing to use one value per line at the NAME_options files, and this remains valid. It was updated to explain how the NAME_options are handled.

@kevmitch thoughts? review?