### PR TITLE
configure/build: add meson support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,21 @@ statically linked with mpv when using the provided scripts, and no ffmpeg or
 libass libraries are/need to be installed. There are no required config or
 data files either.
 
+Meson Support
+=============
+
+These scripts do have support for building with mpv's meson build. They are not
+used by default. To invoke them, you must pass an additional environment variable,
+BUILDSYSTEM=meson to your commands. For example::
+
+    BUILDSYSTEM=meson ./rebuild -j4
+
+The arguments that you pass should conform to meson conventions and not the waf
+ones.
+
+**Note**: The meson scripts specifically invoke the new ``prefer_static`` built-in
+option. This requires a meson version of 0.63 or greater.
+
 Dependencies
 ============
 

--- a/scripts/mpv-build
+++ b/scripts/mpv-build
@@ -2,4 +2,8 @@
 set -e
 
 cd mpv
-python3 ./waf build "$@"
+if [ "$BUILDSYSTEM" = "meson" ]; then
+    meson compile -C build "$@"
+else
+    python3 ./waf build "$@"
+fi

--- a/scripts/mpv-clean
+++ b/scripts/mpv-clean
@@ -4,6 +4,3 @@ test -e mpv || exit 0
 cd mpv
 python3 ./waf distclean # waf clean
 rm -rf build # meson clean
-# waf might pick up some old-configure/makefile produced files
-# also, waf clean won't remove the old binary
-rm -f DOCS/man/*/mpv.1 version.h input/input_conf.h video/out/vdpau_template.c demux/ebml_types.h demux/ebml_defs.c video/out/gl_video_shaders.h video/out/x11_icon.inc sub/osd_font.h player/lua/defaults.inc player/lua/assdraw.inc player/lua/osc.inc mpv

--- a/scripts/mpv-clean
+++ b/scripts/mpv-clean
@@ -2,7 +2,8 @@
 test -e mpv || exit 0
 
 cd mpv
-python3 ./waf distclean
+python3 ./waf distclean # waf clean
+rm -rf build # meson clean
 # waf might pick up some old-configure/makefile produced files
 # also, waf clean won't remove the old binary
 rm -f DOCS/man/*/mpv.1 version.h input/input_conf.h video/out/vdpau_template.c demux/ebml_types.h demux/ebml_defs.c video/out/gl_video_shaders.h video/out/x11_icon.inc sub/osd_font.h player/lua/defaults.inc player/lua/assdraw.inc player/lua/osc.inc mpv

--- a/scripts/mpv-config
+++ b/scripts/mpv-config
@@ -20,11 +20,15 @@ case "$PKG_CONFIG_PATH" in
     ;;
 esac
 
-# add missing private dependencies from libass.pc
-# this is necessary due to the hybrid static / dynamic nature of the build
-export LDFLAGS="$LDFLAGS $(pkg-config --libs fontconfig harfbuzz fribidi)"
-
 echo Using mpv options: "$@"
 
 cd "$BUILD"/mpv
-python3 ./waf configure "$@"
+
+if [ "$BUILDSYSTEM" = "meson" ]; then
+    meson build -Dprefer_static=true -Dbuildtype=release "$@"
+else
+    # add missing private dependencies from libass.pc
+    # this is necessary due to the hybrid static / dynamic nature of the build
+    export LDFLAGS="$LDFLAGS $(pkg-config --libs fontconfig harfbuzz fribidi)"
+    python3 ./waf configure "$@"
+fi

--- a/scripts/mpv-install
+++ b/scripts/mpv-install
@@ -2,4 +2,8 @@
 set -e
 
 cd mpv
-python3 ./waf install
+if [ "$BUILDSYSTEM" = "meson" ]; then
+    meson install -C build
+else
+    python3 ./waf install
+fi

--- a/scripts/mpv-uninstall
+++ b/scripts/mpv-uninstall
@@ -2,4 +2,8 @@
 set -e
 
 cd mpv
-python3 ./waf uninstall
+if [ "$BUILDSYSTEM" = "meson" ]; then
+    ninja uninstall -C build
+else
+    python3 ./waf uninstall
+fi

--- a/scripts/test-libmpv
+++ b/scripts/test-libmpv
@@ -8,8 +8,6 @@ BUILD="$(pwd)"
 
 USER_OPTS="$@"
 if test -f "$BUILD"/mpv_options ; then
-    if cat "$BUILD"/mpv_options | grep -e '--enable-libmpv' > /dev/null ; then
-        exit 0
-    fi
+    grep -Eqe '--enable-libmpv|-Dlibmpv=true' "$BUILD"/mpv_options && exit 0
 fi
 exit 1


### PR DESCRIPTION
Basically this just bolts on the ability to build with meson instead of waf. Waf is still the default though. One limitation, for now, is that it requires a very new meson (git master right now, it will be 0.63+ in a future release) for the `prefer_static` option which makes this build reasonable in the first place. Hopefully the interface is OK, I figured the easy thing would just to make users pass `meson` before any other argument if they wanted to use the meson build.