### PR TITLE
add libplacebo to the build

### DIFF
--- a/build
+++ b/build
@@ -8,5 +8,7 @@ scripts/libass-config
 scripts/libass-build "$@"
 scripts/ffmpeg-config
 scripts/ffmpeg-build "$@"
+scripts/libplacebo-config
+scripts/libplacebo-build "$@"
 scripts/mpv-config
 scripts/mpv-build "$@"

--- a/clean
+++ b/clean
@@ -1,6 +1,7 @@
 #!/bin/sh
 export LC_ALL=C
 
+scripts/libplacebo-clean
 scripts/ffmpeg-clean
 scripts/fribidi-clean
 scripts/libass-clean

--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,7 @@ Build-Depends:
  automake,
  c-compiler | gcc,
  debhelper (>= 7),
+ glslang-dev,
  ladspa-sdk,
  libasound2-dev [linux-any],
  libarchive-dev,
@@ -19,6 +20,7 @@ Build-Depends:
  libdav1d-dev,
  libdvdnav-dev,
  libegl1-mesa-dev,
+ libepoxy-dev,
  libfontconfig-dev,
  libfreetype6-dev,
  libfribidi-dev,
@@ -54,6 +56,7 @@ Build-Depends:
  libvorbis-dev,
  libvo-amrwbenc-dev,
  libvpx-dev,
+ libvulkan-dev,
  libwayland-dev,
  libx264-dev,
  libx11-dev,
@@ -65,6 +68,7 @@ Build-Depends:
  libxss-dev,
  libxv-dev,
  libxvidcore-dev,
+ meson,
  pkg-config,
  python3,
  python3-docutils,
@@ -84,5 +88,5 @@ Description: mplayer/mplayer2 based video player
  MPV is a versatile CLI movie player, based on mplayer and mplayer2.
  .
  This package is not part of Debian. It was created by mpv-build scripts with
- statically linked ffmpeg and libass from upstream.
+ statically linked ffmpeg, libass and libplacebo from upstream.
 Homepage:https://github.com/mpv-player/mpv-build

--- a/debian/rules
+++ b/debian/rules
@@ -11,6 +11,7 @@ ifneq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
 # use MFLAGS, rather than MAKEFLAGS as the latter is used by make internally
 	MFLAGS += -j$(NUMJOBS)
 	WAFFLAGS += -j$(NUMJOBS)
+	NINJAFLAGS += -j$(NUMJOBS)
 endif
 
 # make .PHONY all the targets that have name collisions with the scripts
@@ -59,8 +60,14 @@ ffmpeg_config: libass_build
 ffmpeg_build: ffmpeg_config
 	scripts/ffmpeg-build $(MFLAGS)
 
+libplacebo_config:
+	scripts/libplacebo-config
+
+libplacebo_build: libplacebo_config
+	scripts/libplacebo-build $(NINJAFLAGS)
+
 # put the config in the right place and drop the local/ since it's package managed now
-override_dh_auto_configure: ffmpeg_build libass_build
+override_dh_auto_configure: ffmpeg_build libass_build libplacebo_build
 	scripts/mpv-config --prefix=/usr --confdir=/etc/mpv \
 		--enable-openal \
 		--enable-dvdnav \

--- a/scripts/debian-update-versions
+++ b/scripts/debian-update-versions
@@ -16,8 +16,8 @@ get_version()
 
 do_subst() {
     sed  -e "0,/^mpv (.*)/s/(.*)/($1)/" \
-         -e "s/^  \* local build.*/  \* local build with ffmpeg $2, libass $3/" \
+         -e "s/^  \* local build.*/  \* local build with ffmpeg $2, libass $3, libplacebo $4/" \
          -e"s/\(^ -- Local User <localuser@localhost>\).*/\1  $(date -R)/" debian/changelog.TEMPLATE > debian/changelog
 }
 
-do_subst $(get_version mpv) $(get_version ffmpeg) $(get_version libass)
+do_subst $(get_version mpv) $(get_version ffmpeg) $(get_version libass) $(get_version libplacebo)

--- a/scripts/libplacebo-build
+++ b/scripts/libplacebo-build
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+ninja -C libplacebo_build install "$@"

--- a/scripts/libplacebo-clean
+++ b/scripts/libplacebo-clean
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm -rf libplacebo_build

--- a/scripts/libplacebo-config
+++ b/scripts/libplacebo-config
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -e
+BUILD="$(pwd)"
+newline="
+"
+
+if test -f "$BUILD"/libplacebo_options ; then
+    IFS=$newline
+    set -- $(cat "$BUILD"/libplacebo_options) "$@"
+    unset -v IFS
+fi
+
+OPTIONS="--default-library static -Dtests=false -Ddemos=false"
+
+case "$PKG_CONFIG_PATH" in
+  '')
+    export PKG_CONFIG_PATH="$BUILD/build_libs/lib/pkgconfig"
+    ;;
+  *)
+    export PKG_CONFIG_PATH="$BUILD/build_libs/lib/pkgconfig:$PKG_CONFIG_PATH"
+    ;;
+esac
+
+BUILDDIR="$BUILD"/libplacebo_build
+test -d "$BUILDDIR" && OPTIONS="$OPTIONS --wipe"
+mkdir -p "$BUILDDIR"
+cd "$BUILD"/libplacebo
+meson "$BUILDDIR" --prefix="$BUILD"/build_libs --libdir="$BUILD"/build_libs/lib $OPTIONS "$@"

--- a/scripts/mpv-config
+++ b/scripts/mpv-config
@@ -29,6 +29,7 @@ if [ "$BUILDSYSTEM" = "meson" ]; then
 else
     # add missing private dependencies from libass.pc
     # this is necessary due to the hybrid static / dynamic nature of the build
-    export LDFLAGS="$LDFLAGS $(pkg-config --libs fontconfig harfbuzz fribidi)"
+    # -lstdc++ is required by gslang (via libplacebo) and possibly others
+    export LDFLAGS="$LDFLAGS $(pkg-config --libs fontconfig harfbuzz fribidi libplacebo) -lstdc++"
     python3 ./waf configure "$@"
 fi

--- a/update
+++ b/update
@@ -11,6 +11,7 @@ do_clone()
         cd "$1"
         git remote set-url origin "$2"
         git fetch
+        git submodule update --init
     )
 }
 
@@ -20,6 +21,7 @@ do_clone_all()
     #do_clone "fribidi"  "http://anongit.freedesktop.org/git/fribidi/fribidi.git"
     do_clone "libass"   "https://github.com/libass/libass.git"
     do_clone "mpv"      "https://github.com/mpv-player/mpv.git"
+    do_clone "libplacebo" "https://github.com/haasn/libplacebo.git"
 }
 
 do_gitmaster()
@@ -47,7 +49,7 @@ do_releasetag()
     local prefix=  # by default, don't use a prefix
     case "$1" in
         ffmpeg) prefix=n;;  # e.g. n3.3.1
-        mpv)    prefix=v;;  # e.g. v0.26.0
+        mpv|libplacebo) prefix=v;;  # e.g. v0.26.0
     esac
 
     (
@@ -87,6 +89,7 @@ checkout_ffmpeg=master
 #checkout_fribidi=release
 checkout_libass=master
 checkout_mpv=master
+checkout_libplacebo=master
 
 
 checkout_all()
@@ -97,6 +100,7 @@ checkout_all()
     #$checkout fribidi $checkout_fribidi
     checkout libass $checkout_libass
     checkout mpv $checkout_mpv
+    checkout libplacebo $checkout_libplacebo
 }
 
 do_bootstrap()
@@ -125,10 +129,12 @@ case "$1" in
         #checkout_fribidi="master -"
         checkout_libass="master -"
         checkout_mpv="master -"
+        checkout_libplacebo="master -"
         ;;
     --release)
         checkout_ffmpeg="release -"
         checkout_mpv="release -"
+        checkout_libplacebo="release -"
         ;;
     '')
         ;;


### PR DESCRIPTION
Debian's version is old and crusty and a newer version of libplacebo is required for gpu-next.

I've tested building both with and without the debian package. Also tested building and linking libmpv with 
https://github.com/mpv-player/mpv-examples/blob/master/libmpv/simple/simple.c
