### PR TITLE
libplacebo-build script: fix meson command

### DIFF
--- a/scripts/libplacebo-build
+++ b/scripts/libplacebo-build
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 
-ninja install -C libplacebo/build "$@"
+ninja -C libplacebo/build "$@" install


### PR DESCRIPTION
without this meson fails on alpine edge for whatever reason