### PR TITLE
scripts/mpv-config: pass -Wl,-Bsymbolic when building libmpv

### DIFF
--- a/scripts/mpv-config
+++ b/scripts/mpv-config
@@ -11,6 +11,11 @@ if test -f "$BUILD"/mpv_options ; then
     unset -v IFS
 fi
 
+OPTIONS=""
+if "$BUILD"/scripts/test-libmpv && [ "$BUILDSYSTEM" != "waf" ]; then
+    OPTIONS="$OPTIONS -Dc_link_args='-Wl,-Bsymbolic'"
+fi
+
 case "$PKG_CONFIG_PATH" in
   '')
     export PKG_CONFIG_PATH="$BUILD/build_libs/lib/pkgconfig"
@@ -20,7 +25,7 @@ case "$PKG_CONFIG_PATH" in
     ;;
 esac
 
-echo Using mpv options: "$@"
+echo Using mpv options: $OPTIONS "$@"
 
 cd "$BUILD"/mpv
 
@@ -32,5 +37,5 @@ export LDFLAGS="$LDFLAGS $(pkg-config --libs fontconfig harfbuzz fribidi) -lstdc
 if [ "$BUILDSYSTEM" = "waf" ]; then
     python3 ./waf configure "$@"
 else
-    meson setup build -Dbuildtype=release "$@"
+    meson setup build -Dbuildtype=release $OPTIONS "$@"
 fi


### PR DESCRIPTION
According to ffmpeg's own documentation* we have to add these linker flags to libmpv when building it against the static library. waf doesn't need this for mysterious, unknown reasons (the linker flags there are a bit different) but passing this works fine on meson. Just add an extra check to the mpv-config script to enable this if needed. Fixes #208.

*: https://ffmpeg.org/platform.html#Advanced-linking-configuration