### PR TITLE
hopefully fix shared / private mess for mpv meson build

### DIFF
--- a/scripts/mpv-config
+++ b/scripts/mpv-config
@@ -24,13 +24,13 @@ echo Using mpv options: "$@"
 
 cd "$BUILD"/mpv
 
+# add missing private dependencies from libass.pc
+# this is necessary due to the hybrid static / dynamic nature of the build
+# need to link against stdc++ in case libplacebo was built with glslang,
+# which requires that
+export LDFLAGS="$LDFLAGS $(pkg-config --libs fontconfig harfbuzz fribidi) -lstdc++"
 if [ "$BUILDSYSTEM" = "waf" ]; then
-    # add missing private dependencies from libass.pc
-    # this is necessary due to the hybrid static / dynamic nature of the build
-    # need to link against stdc++ in case libplacebo was built with glslang,
-    # which requires that
-    export LDFLAGS="$LDFLAGS $(pkg-config --libs fontconfig harfbuzz fribidi) -lstdc++"
     python3 ./waf configure "$@"
 else
-    meson setup build -Dprefer_static=true -Dbuildtype=release "$@"
+    meson setup build -Dbuildtype=release "$@"
 fi


### PR DESCRIPTION
Using meson to build mpv with prefer_static=true would try to link everything statically including things provided by the system. For example, if both shared and static versions of libarchive are were available, it would choose the static version.  This would work until it tried to actulaly link the mpv binary which would additionally require static versions of -lacl, lzlib, etc. These build dependencies can be avoided if it instead links to shared libarchive.

To avoid this, don't use -Dprefer_static=true. It should already be preferring the specifically statically built libs in build_libs because they are added first in the pkg-config path.

Of course, we still run into the same -lstdc++ issue that we saw with waf, so that hack needs to be made general to both build systems.