### PR TITLE
scripts/mpv-config: check platform when adding flags

### DIFF
--- a/scripts/mpv-config
+++ b/scripts/mpv-config
@@ -12,7 +12,10 @@ if test -f "$BUILD"/mpv_options ; then
 fi
 
 if "$BUILD"/scripts/test-libmpv; then
-    OPTIONS="-Dc_link_args='-Wl,-Bsymbolic'"
+    platform=$(uname | tr '[:upper:]' '[:lower:]')
+    case "$platform" in
+    *bsd*|*linux*|*solaris*) OPTIONS="-Dc_link_args='-Wl,-Bsymbolic'" ;;
+    esac
 fi
 
 case "$PKG_CONFIG_PATH" in


### PR DESCRIPTION
When building libmpv against the static ffmpeg libraries, we have to add the -Wl,-Bsymbolic linker flags. The problem is that these are only valid for ELF which doesn't apply to all OSes (namely, macOS). Solve this by simply checking the output from uname and seeing if it matches a known ELF platform like linux, bsd, or solaris (who uses this?). Fixes #216.