### PR TITLE
scripts/mpv-config: remove -Bsymbolic linker flag

### DIFF
--- a/scripts/mpv-config
+++ b/scripts/mpv-config
@@ -11,13 +11,6 @@ if test -f "$BUILD"/mpv_options ; then
     unset -v IFS
 fi
 
-if "$BUILD"/scripts/test-libmpv; then
-    platform=$(uname | tr '[:upper:]' '[:lower:]')
-    case "$platform" in
-    *bsd*|*linux*|*solaris*) OPTIONS="-Dc_link_args='-Wl,-Bsymbolic'" ;;
-    esac
-fi
-
 case "$PKG_CONFIG_PATH" in
   '')
     export PKG_CONFIG_PATH="$BUILD/build_libs/lib/pkgconfig"


### PR DESCRIPTION
It shouldn't be added unconditionally and with all the fragile checks if it is supported it is way better to handle it in the meson itself.

See also:
https://github.com/mpv-player/mpv/pull/12346

Fixes:
https://github.com/mpv-player/mpv-build/issues/215
https://github.com/haasn/libplacebo/issues/198