### PR TITLE
debian: add libdisplay-info-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,6 +16,7 @@ Build-Depends:
  libbs2b-dev,
  libcaca-dev,
  libcdio-paranoia-dev,
+ libdisplay-info-dev,
  libdrm-dev,
  libdav1d-dev,
  libdvdnav-dev,


### PR DESCRIPTION
This is now needed for the drm context since
https://github.com/mpv-player/mpv/commit/a4d9bdd262b808d0c8663d28023ff21fef862803